### PR TITLE
Use builtin `getLambdaLogicalId` to let you use the name in serverles…

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,12 +23,13 @@ class LambdaArn {
           .LambdaFunctionAssociations;
 
       _.forEach(associations, association => {
-        const arn = association.LambdaFunctionARN;
-        const versionRef = this.getArnAndVersion(compiledResources, arn);
-        if (arn && versionRef) {
+        const funcName = association.LambdaFunctionARN;
+        const logicalId = this.serverless.providers.aws.naming.getLambdaLogicalId(funcName);
+        const versionRef = this.getArnAndVersion(compiledResources, logicalId)
+        if (logicalId && versionRef) {
           this.serverless.cli.log(
             `serverless-lambda-version: injecting arn+version for ${JSON.stringify(
-              arn
+              logicalId
             )}`
           );
           association.LambdaFunctionARN = versionRef;
@@ -47,16 +48,7 @@ class LambdaArn {
       }
     });
     return key
-      ? {
-        'Fn::Join': [
-          '',
-          [
-            { 'Fn::GetAtt': [ funcNormName, 'Arn' ] },
-            ':',
-            { 'Fn::GetAtt': [ key, 'Version' ] }
-          ]
-        ]
-      }
+      ? {Ref: key}
       : undefined;
   }
 


### PR DESCRIPTION
…s.yml

Also switch from using ::Join to build the ARN to using the `Ref` return
value on the aws::lambda::version resource.


Now in your serverless.yml if you have:

```
functions:
  my-function:
    handler: ....
    other_options:....

resources:
  Resources:
    CloudFront:
      Type: "AWS::CloudFront::Distribution"
      ....
      DefaultCacheBehavior:
        LambdaFunctionAssociations:
        - EventType: ...
          LambdaFunctionArn: my-function
```

and it will find the right CloudFormation resource (for the function) and fill in `{Ref: [lambda::version resource]}` so you don't need to know the fancy rules Serverless uses to generate names